### PR TITLE
test: unit tests for Phase 2+3 code achieving ≥80% coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "happy-dom": "^20.8.9",
         "husky": "^9.1.7",
         "jsdom": "^27.0.1",
         "lint-staged": "^16.4.0",
@@ -4179,6 +4180,23 @@
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
@@ -7085,6 +7103,47 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/happy-dom": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/has-flag": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "happy-dom": "^20.8.9",
     "husky": "^9.1.7",
     "jsdom": "^27.0.1",
     "lint-staged": "^16.4.0",

--- a/src/infrastructure/api/footballApi.test.ts
+++ b/src/infrastructure/api/footballApi.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
+
+// Mock env module BEFORE importing footballApi
+vi.mock('@/shared/config/env', () => ({
+  env: {
+    apiFootballKey: 'test-key',
+    apiFootballBaseUrl: 'https://v3.football.api-sports.io',
+    useMockData: true,
+    teamId: 33,
+    apiRateLimit: 100,
+  },
+}));
+
+import {
+  getApiRequestCount,
+  incrementApiRequestCount,
+  isApiLimitReached,
+  ApiLimitError,
+} from './footballApi';
+
+describe('footballApi - rate limit counter', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+  });
+
+  it('getApiRequestCount returns 0 when no data stored', () => {
+    expect(getApiRequestCount()).toBe(0);
+  });
+
+  it('getApiRequestCount returns 0 on a new day (different stored date)', () => {
+    // Store old date
+    localStorage.setItem('mufc_api_requests_date', '2020-01-01');
+    localStorage.setItem('mufc_api_requests', '50');
+    const count = getApiRequestCount();
+    expect(count).toBe(0);
+  });
+
+  it('getApiRequestCount returns correct count for today', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('mufc_api_requests_date', today);
+    localStorage.setItem('mufc_api_requests', '42');
+    expect(getApiRequestCount()).toBe(42);
+  });
+
+  it('incrementApiRequestCount increases count by 1', () => {
+    expect(getApiRequestCount()).toBe(0);
+    incrementApiRequestCount();
+    expect(getApiRequestCount()).toBe(1);
+    incrementApiRequestCount();
+    expect(getApiRequestCount()).toBe(2);
+  });
+
+  it('isApiLimitReached returns false when below limit', () => {
+    expect(isApiLimitReached()).toBe(false);
+  });
+
+  it('isApiLimitReached returns true when count equals limit (100)', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('mufc_api_requests_date', today);
+    localStorage.setItem('mufc_api_requests', '100');
+    expect(isApiLimitReached()).toBe(true);
+  });
+
+  it('isApiLimitReached returns true when count exceeds limit', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('mufc_api_requests_date', today);
+    localStorage.setItem('mufc_api_requests', '150');
+    expect(isApiLimitReached()).toBe(true);
+  });
+
+  it('counter resets to 0 on a new day', () => {
+    // Set old date with high count
+    localStorage.setItem('mufc_api_requests_date', '2000-01-01');
+    localStorage.setItem('mufc_api_requests', '99');
+    // Calling getApiRequestCount with a new day should reset
+    const count = getApiRequestCount();
+    expect(count).toBe(0);
+    // And the date should now be today
+    const today = new Date().toISOString().slice(0, 10);
+    expect(localStorage.getItem('mufc_api_requests_date')).toBe(today);
+  });
+});
+
+describe('ApiLimitError', () => {
+  it('has correct message', () => {
+    const error = new ApiLimitError();
+    expect(error.message).toBe('API rate limit reached for today');
+  });
+
+  it('has correct name', () => {
+    const error = new ApiLimitError();
+    expect(error.name).toBe('ApiLimitError');
+  });
+
+  it('is an instance of Error', () => {
+    const error = new ApiLimitError();
+    expect(error).toBeInstanceOf(Error);
+  });
+});

--- a/src/presentation/components/charts/MatchStatsChart.test.tsx
+++ b/src/presentation/components/charts/MatchStatsChart.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { MatchStatsChart } from './MatchStatsChart';
+
+const mockStats = [
+  { label: 'Possession', home: 55, away: 45 },
+  { label: 'Shots', home: 12, away: 8 },
+  { label: 'Passes', home: 500, away: 400 },
+];
+
+describe('MatchStatsChart', () => {
+  it('renders without crashing', () => {
+    render(<MatchStatsChart stats={mockStats} homeTeam="Man United" awayTeam="Liverpool" />);
+    expect(screen.getByText('Man United')).toBeInTheDocument();
+  });
+
+  it('renders home team name', () => {
+    render(<MatchStatsChart stats={mockStats} homeTeam="Man United" awayTeam="Liverpool" />);
+    expect(screen.getByText('Man United')).toBeInTheDocument();
+  });
+
+  it('renders away team name', () => {
+    render(<MatchStatsChart stats={mockStats} homeTeam="Man United" awayTeam="Liverpool" />);
+    expect(screen.getByText('Liverpool')).toBeInTheDocument();
+  });
+
+  it('renders all stat labels', () => {
+    render(<MatchStatsChart stats={mockStats} homeTeam="Man United" awayTeam="Liverpool" />);
+    expect(screen.getByText('Possession')).toBeInTheDocument();
+    expect(screen.getByText('Shots')).toBeInTheDocument();
+    expect(screen.getByText('Passes')).toBeInTheDocument();
+  });
+
+  it('renders home stat values', () => {
+    render(<MatchStatsChart stats={mockStats} homeTeam="Man United" awayTeam="Liverpool" />);
+    expect(screen.getByText('55')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('renders away stat values', () => {
+    render(<MatchStatsChart stats={mockStats} homeTeam="Man United" awayTeam="Liverpool" />);
+    expect(screen.getByText('45')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('handles zero values (total = 0 → uses 1 to avoid division by zero)', () => {
+    const zeroStats = [{ label: 'Fouls', home: 0, away: 0 }];
+    render(<MatchStatsChart stats={zeroStats} homeTeam="Man United" awayTeam="Liverpool" />);
+    expect(screen.getByText('Fouls')).toBeInTheDocument();
+  });
+
+  it('renders with empty stats array', () => {
+    const { container } = render(
+      <MatchStatsChart stats={[]} homeTeam="Man United" awayTeam="Liverpool" />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/charts/PlayerRadarChart.test.tsx
+++ b/src/presentation/components/charts/PlayerRadarChart.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { PlayerRadarChart } from './PlayerRadarChart';
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  RadarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="radar-chart">{children}</div>
+  ),
+  Radar: () => null,
+  PolarGrid: () => null,
+  PolarAngleAxis: () => null,
+}));
+
+const mockData = [
+  { attribute: 'Pace', value: 85, fullMark: 100 },
+  { attribute: 'Shooting', value: 80, fullMark: 100 },
+  { attribute: 'Passing', value: 75, fullMark: 100 },
+  { attribute: 'Dribbling', value: 88, fullMark: 100 },
+  { attribute: 'Defending', value: 40, fullMark: 100 },
+  { attribute: 'Physical', value: 70, fullMark: 100 },
+];
+
+describe('PlayerRadarChart', () => {
+  it('renders without crashing', () => {
+    render(<PlayerRadarChart data={mockData} />);
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('renders RadarChart', () => {
+    render(<PlayerRadarChart data={mockData} />);
+    expect(screen.getByTestId('radar-chart')).toBeInTheDocument();
+  });
+
+  it('renders with custom color', () => {
+    const { container } = render(<PlayerRadarChart data={mockData} color="#00ff00" />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders with empty data', () => {
+    render(<PlayerRadarChart data={[]} />);
+    expect(screen.getByTestId('radar-chart')).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/charts/SeasonPerformanceChart.test.tsx
+++ b/src/presentation/components/charts/SeasonPerformanceChart.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { SeasonPerformanceChart } from './SeasonPerformanceChart';
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  AreaChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="area-chart">{children}</div>
+  ),
+  Area: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+}));
+
+const mockData = [
+  { matchday: 'GW1', goals: 2, goalsAgainst: 1, points: 3 },
+  { matchday: 'GW2', goals: 0, goalsAgainst: 0, points: 1 },
+  { matchday: 'GW3', goals: 3, goalsAgainst: 2, points: 3 },
+];
+
+describe('SeasonPerformanceChart', () => {
+  it('renders without crashing', () => {
+    render(<SeasonPerformanceChart data={mockData} />);
+    expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
+  });
+
+  it('renders AreaChart', () => {
+    render(<SeasonPerformanceChart data={mockData} />);
+    expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+  });
+
+  it('renders with empty data', () => {
+    render(<SeasonPerformanceChart data={[]} />);
+    expect(screen.getByTestId('area-chart')).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/feedback/ApiLimitReached.test.tsx
+++ b/src/presentation/components/feedback/ApiLimitReached.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { ApiLimitReached } from './ApiLimitReached';
+
+describe('ApiLimitReached', () => {
+  it('renders used/max request count', () => {
+    render(<ApiLimitReached usedRequests={95} maxRequests={100} />);
+    expect(screen.getByText('95/100')).toBeInTheDocument();
+  });
+
+  it('renders the overlay with fixed positioning', () => {
+    const { container } = render(<ApiLimitReached usedRequests={100} maxRequests={100} />);
+    const overlay = container.firstChild as HTMLElement;
+    expect(overlay.className).toContain('fixed');
+    expect(overlay.className).toContain('inset-0');
+  });
+
+  it('renders API Limit Reached title', () => {
+    render(<ApiLimitReached usedRequests={100} maxRequests={100} />);
+    expect(screen.getByText('API Limit Reached')).toBeInTheDocument();
+  });
+
+  it('renders the maxRequests in the description', () => {
+    render(<ApiLimitReached usedRequests={100} maxRequests={100} />);
+    expect(
+      screen.getByText(/The free tier of API Football allows 100 requests per day/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders reset date when provided', () => {
+    render(<ApiLimitReached usedRequests={100} maxRequests={100} resetDate="2026-03-27" />);
+    expect(screen.getByText(/Your limit resets on 2026-03-27/)).toBeInTheDocument();
+  });
+
+  it('does not render reset date text when not provided', () => {
+    render(<ApiLimitReached usedRequests={100} maxRequests={100} />);
+    expect(screen.queryByText(/Your limit resets on/)).not.toBeInTheDocument();
+  });
+
+  it('shows cached data message', () => {
+    render(<ApiLimitReached usedRequests={100} maxRequests={100} />);
+    expect(screen.getByText(/using cached data/i)).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/feedback/EmptyState.test.tsx
+++ b/src/presentation/components/feedback/EmptyState.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { EmptyState } from './EmptyState';
+
+describe('EmptyState', () => {
+  it('renders default title when no title provided', () => {
+    render(<EmptyState />);
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('renders default description when no description provided', () => {
+    render(<EmptyState />);
+    expect(screen.getByText('There is no data to display at the moment.')).toBeInTheDocument();
+  });
+
+  it('renders custom title', () => {
+    render(<EmptyState title="No fixtures found" />);
+    expect(screen.getByText('No fixtures found')).toBeInTheDocument();
+  });
+
+  it('renders custom description', () => {
+    render(<EmptyState description="Try adjusting your filters." />);
+    expect(screen.getByText('Try adjusting your filters.')).toBeInTheDocument();
+  });
+
+  it('renders custom icon when provided', () => {
+    const icon = <span data-testid="custom-icon">📭</span>;
+    render(<EmptyState icon={icon} />);
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('renders default Inbox icon when no custom icon', () => {
+    const { container } = render(<EmptyState />);
+    // lucide-react renders SVGs
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/feedback/ErrorMessage.test.tsx
+++ b/src/presentation/components/feedback/ErrorMessage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ErrorMessage } from './ErrorMessage';
+
+describe('ErrorMessage', () => {
+  it('renders default message when no message prop', () => {
+    render(<ErrorMessage />);
+    expect(screen.getByText('An error occurred while loading data.')).toBeInTheDocument();
+  });
+
+  it('renders custom message', () => {
+    render(<ErrorMessage message="Network connection failed." />);
+    expect(screen.getByText('Network connection failed.')).toBeInTheDocument();
+  });
+
+  it('renders "Something went wrong" heading', () => {
+    render(<ErrorMessage />);
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('renders retry button when onRetry is provided', () => {
+    render(<ErrorMessage onRetry={() => {}} />);
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('does NOT render retry button when onRetry is not provided', () => {
+    render(<ErrorMessage />);
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+  });
+
+  it('calls onRetry when button is clicked', () => {
+    const onRetry = vi.fn();
+    render(<ErrorMessage onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/presentation/components/feedback/LoadingSpinner.test.tsx
+++ b/src/presentation/components/feedback/LoadingSpinner.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+import { LoadingSpinner, LoadingPage } from './LoadingSpinner';
+
+describe('LoadingSpinner', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<LoadingSpinner />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders with size sm', () => {
+    const { container } = render(<LoadingSpinner size="sm" />);
+    const spinner = container.querySelector('.w-4');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('renders with size md (default)', () => {
+    const { container } = render(<LoadingSpinner size="md" />);
+    const spinner = container.querySelector('.w-8');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('renders with size lg', () => {
+    const { container } = render(<LoadingSpinner size="lg" />);
+    const spinner = container.querySelector('.w-12');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(<LoadingSpinner className="custom-class" />);
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('renders with animate-spin class', () => {
+    const { container } = render(<LoadingSpinner />);
+    const spinner = container.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+  });
+});
+
+describe('LoadingPage', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<LoadingPage />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders a large spinner', () => {
+    const { container } = render(<LoadingPage />);
+    const spinner = container.querySelector('.w-12');
+    expect(spinner).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/layout/Header.test.tsx
+++ b/src/presentation/components/layout/Header.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Header } from './Header';
+import { ThemeProvider } from '@/presentation/components/ui/ThemeProvider';
+
+function renderHeader(props: Partial<Parameters<typeof Header>[0]> = {}) {
+  return render(
+    <ThemeProvider defaultTheme="dark">
+      <Header onMenuToggle={() => {}} {...props} />
+    </ThemeProvider>
+  );
+}
+
+describe('Header', () => {
+  it('renders default title when no title prop', () => {
+    renderHeader();
+    expect(screen.getByText('Season Overview')).toBeInTheDocument();
+  });
+
+  it('renders custom title', () => {
+    renderHeader({ title: 'Player Stats' });
+    expect(screen.getByText('Player Stats')).toBeInTheDocument();
+  });
+
+  it('renders subtitle when provided', () => {
+    renderHeader({ subtitle: 'Premier League 2024/25' });
+    expect(screen.getByText('Premier League 2024/25')).toBeInTheDocument();
+  });
+
+  it('does not render subtitle when not provided', () => {
+    renderHeader();
+    expect(screen.queryByText('Premier League 2024/25')).not.toBeInTheDocument();
+  });
+
+  it('calls onMenuToggle when menu button is clicked', () => {
+    const onMenuToggle = vi.fn();
+    renderHeader({ onMenuToggle });
+    // The menu button uses variant=ghost, size=icon
+    const buttons = screen.getAllByRole('button');
+    // First button is the menu toggle
+    fireEvent.click(buttons[0]);
+    expect(onMenuToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders theme toggle button', () => {
+    renderHeader();
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders Avatar with DS fallback', () => {
+    renderHeader();
+    expect(screen.getByText('DS')).toBeInTheDocument();
+  });
+
+  it('toggles theme when theme button is clicked', () => {
+    renderHeader();
+    const buttons = screen.getAllByRole('button');
+    // Second button is the theme toggle
+    const themeButton = buttons[1];
+    // Should show Sun icon when dark (since dark→click→light shows Moon)
+    fireEvent.click(themeButton);
+    // After click from dark, should switch to light
+    // We just verify it doesn't crash and re-renders
+    expect(screen.getByText('Season Overview')).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/layout/Sidebar.test.tsx
+++ b/src/presentation/components/layout/Sidebar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+
+function renderSidebar(props = {}, initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Sidebar {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe('Sidebar', () => {
+  it('renders MAN UNITED logo text', () => {
+    renderSidebar();
+    expect(screen.getByText('MAN UNITED')).toBeInTheDocument();
+  });
+
+  it('renders Analytics subtitle', () => {
+    renderSidebar();
+    expect(screen.getByText('Analytics')).toBeInTheDocument();
+  });
+
+  it('renders all nav items', () => {
+    renderSidebar();
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Standings')).toBeInTheDocument();
+    expect(screen.getByText('Player Stats')).toBeInTheDocument();
+    expect(screen.getByText('Live Match')).toBeInTheDocument();
+    expect(screen.getByText('Tactical Analysis')).toBeInTheDocument();
+    expect(screen.getByText('Injuries')).toBeInTheDocument();
+    expect(screen.getByText('Calendar')).toBeInTheDocument();
+    expect(screen.getByText('Records')).toBeInTheDocument();
+  });
+
+  it('applies active class to current route link', () => {
+    renderSidebar({}, '/standings');
+    const standingsLink = screen.getByText('Standings').closest('a');
+    expect(standingsLink?.className).toContain('bg-mufc-red');
+  });
+
+  it('does not apply active class to non-current route links', () => {
+    renderSidebar({}, '/standings');
+    const overviewLink = screen.getByText('Overview').closest('a');
+    expect(overviewLink?.className).not.toContain('bg-mufc-red');
+  });
+
+  it('calls onClose when a nav item is clicked', () => {
+    const onClose = vi.fn();
+    renderSidebar({ onClose });
+    fireEvent.click(screen.getByText('Overview'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nav links with correct hrefs', () => {
+    renderSidebar();
+    const overviewLink = screen.getByText('Overview').closest('a');
+    expect(overviewLink).toHaveAttribute('href', '/');
+    const standingsLink = screen.getByText('Standings').closest('a');
+    expect(standingsLink).toHaveAttribute('href', '/standings');
+  });
+});

--- a/src/presentation/components/stats/MatchCard.test.tsx
+++ b/src/presentation/components/stats/MatchCard.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import { MatchCard } from './MatchCard';
+import type { Fixture } from '@/shared/types/football';
+
+const mockFinishedFixture: Fixture = {
+  id: 1,
+  date: '2025-03-22T15:00:00+00:00',
+  timestamp: 1742655600,
+  status: { long: 'Match Finished', short: 'FT', elapsed: 90 },
+  homeTeam: { id: 33, name: 'Manchester United', logo: '', shortName: 'MUN' },
+  awayTeam: { id: 48, name: 'West Ham', logo: '', shortName: 'WHU' },
+  homeGoals: 3,
+  awayGoals: 1,
+  league: { id: 39, name: 'Premier League', logo: '', round: 'Regular Season - 30' },
+  venue: { name: 'Old Trafford', city: 'Manchester' },
+};
+
+const mockUpcomingFixture: Fixture = {
+  id: 2,
+  date: '2099-05-01T15:00:00+00:00',
+  timestamp: 4082572800,
+  status: { long: 'Not Started', short: 'NS', elapsed: null },
+  homeTeam: { id: 33, name: 'Manchester United', logo: '', shortName: 'MUN' },
+  awayTeam: { id: 40, name: 'Liverpool', logo: '', shortName: 'LIV' },
+  homeGoals: null,
+  awayGoals: null,
+  league: { id: 39, name: 'Premier League', logo: '', round: 'Regular Season - 35' },
+  venue: { name: 'Old Trafford', city: 'Manchester' },
+};
+
+const mockLiveFixture: Fixture = {
+  id: 3,
+  date: '2025-03-22T15:00:00+00:00',
+  timestamp: 1742655600,
+  status: { long: 'First Half', short: '1H', elapsed: 35 },
+  homeTeam: { id: 33, name: 'Manchester United', logo: '', shortName: 'MUN' },
+  awayTeam: { id: 49, name: 'Chelsea', logo: '', shortName: 'CHE' },
+  homeGoals: 1,
+  awayGoals: 0,
+  league: { id: 39, name: 'Premier League', logo: '', round: 'Regular Season - 30' },
+  venue: { name: 'Old Trafford', city: 'Manchester' },
+};
+
+const mockDrawFixture: Fixture = {
+  ...mockFinishedFixture,
+  id: 4,
+  homeGoals: 2,
+  awayGoals: 2,
+  homeTeam: { id: 48, name: 'West Ham', logo: '', shortName: 'WHU' },
+  awayTeam: { id: 33, name: 'Manchester United', logo: '', shortName: 'MUN' },
+};
+
+const mockLossFixture: Fixture = {
+  ...mockFinishedFixture,
+  id: 5,
+  homeGoals: 3,
+  awayGoals: 0,
+  homeTeam: { id: 48, name: 'West Ham', logo: '', shortName: 'WHU' },
+  awayTeam: { id: 33, name: 'Manchester United', logo: '', shortName: 'MUN' },
+};
+
+describe('MatchCard', () => {
+  it('renders home and away team names', () => {
+    render(<MatchCard fixture={mockFinishedFixture} />);
+    expect(screen.getByText('Manchester United')).toBeInTheDocument();
+    expect(screen.getByText('West Ham')).toBeInTheDocument();
+  });
+
+  it('renders score when match is finished (status FT)', () => {
+    render(<MatchCard fixture={mockFinishedFixture} />);
+    expect(screen.getByText('3 - 1')).toBeInTheDocument();
+  });
+
+  it('renders clock icon area (no score) when match not started (status NS)', () => {
+    render(<MatchCard fixture={mockUpcomingFixture} />);
+    // Score should not show for upcoming
+    expect(screen.queryByText(/\d+ - \d+/)).not.toBeInTheDocument();
+  });
+
+  it('renders LIVE badge when status is 1H', () => {
+    render(<MatchCard fixture={mockLiveFixture} />);
+    expect(screen.getByText(/LIVE/)).toBeInTheDocument();
+  });
+
+  it('shows W badge when MU wins as home team', () => {
+    render(<MatchCard fixture={mockFinishedFixture} muTeamId={33} />);
+    expect(screen.getByText('W')).toBeInTheDocument();
+  });
+
+  it('shows D badge when result is draw (MU as away team)', () => {
+    render(<MatchCard fixture={mockDrawFixture} muTeamId={33} />);
+    expect(screen.getByText('D')).toBeInTheDocument();
+  });
+
+  it('shows L badge when MU loses as away team', () => {
+    render(<MatchCard fixture={mockLossFixture} muTeamId={33} />);
+    expect(screen.getByText('L')).toBeInTheDocument();
+  });
+
+  it('renders league name', () => {
+    render(<MatchCard fixture={mockFinishedFixture} />);
+    expect(screen.getByText('Premier League')).toBeInTheDocument();
+  });
+
+  it('renders round info', () => {
+    render(<MatchCard fixture={mockFinishedFixture} />);
+    expect(screen.getByText('Regular Season - 30')).toBeInTheDocument();
+  });
+
+  it('renders score for live match', () => {
+    render(<MatchCard fixture={mockLiveFixture} />);
+    expect(screen.getByText('1 - 0')).toBeInTheDocument();
+  });
+
+  it('renders AET status as finished', () => {
+    const aetFixture: Fixture = {
+      ...mockFinishedFixture,
+      status: { long: 'After Extra Time', short: 'AET', elapsed: 120 },
+    };
+    render(<MatchCard fixture={aetFixture} />);
+    expect(screen.getByText('3 - 1')).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/stats/PlayerCard.test.tsx
+++ b/src/presentation/components/stats/PlayerCard.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from '@testing-library/react';
+import { PlayerCard } from './PlayerCard';
+import type { PlayerStats } from '@/shared/types/football';
+
+const mockPlayerStats: PlayerStats = {
+  player: {
+    id: 276,
+    name: 'Marcus Rashford',
+    age: 27,
+    nationality: 'England',
+    position: 'Attacker',
+    photo: '',
+  },
+  statistics: [
+    {
+      games: {
+        appearances: 30,
+        lineups: 28,
+        minutes: 2400,
+        number: 10,
+        position: 'Attacker',
+        rating: '7.5',
+        captain: false,
+      },
+      goals: {
+        total: 12,
+        conceded: 0,
+        assists: 5,
+        saves: null,
+      },
+      shots: { total: 55, on: 28 },
+      passes: { total: 600, key: 40, accuracy: '78' },
+      tackles: { total: 20, blocks: 3, interceptions: 10 },
+      cards: { yellow: 2, yellowred: 0, red: 0 },
+    },
+  ],
+};
+
+const mockGoalkeeperStats: PlayerStats = {
+  player: {
+    id: 100,
+    name: 'Andre Onana',
+    age: 28,
+    nationality: 'Cameroon',
+    position: 'Goalkeeper',
+    photo: '',
+  },
+  statistics: [
+    {
+      games: {
+        appearances: 32,
+        lineups: 32,
+        minutes: 2880,
+        number: 24,
+        position: 'Goalkeeper',
+        rating: '6.9',
+        captain: false,
+      },
+      goals: {
+        total: null,
+        conceded: 38,
+        assists: null,
+        saves: 90,
+      },
+      shots: { total: null, on: null },
+      passes: { total: 800, key: 5, accuracy: '85' },
+      tackles: { total: 2, blocks: 1, interceptions: 2 },
+      cards: { yellow: 1, yellowred: 0, red: 0 },
+    },
+  ],
+};
+
+describe('PlayerCard', () => {
+  it('renders player name', () => {
+    render(<PlayerCard playerStats={mockPlayerStats} />);
+    expect(screen.getByText('Marcus Rashford')).toBeInTheDocument();
+  });
+
+  it('renders nationality', () => {
+    render(<PlayerCard playerStats={mockPlayerStats} />);
+    expect(screen.getByText('England')).toBeInTheDocument();
+  });
+
+  it('renders goals count', () => {
+    render(<PlayerCard playerStats={mockPlayerStats} />);
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('renders assists count', () => {
+    render(<PlayerCard playerStats={mockPlayerStats} />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('renders appearances count', () => {
+    render(<PlayerCard playerStats={mockPlayerStats} />);
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+
+  it('renders position badge', () => {
+    render(<PlayerCard playerStats={mockPlayerStats} />);
+    expect(screen.getByText('Attacker')).toBeInTheDocument();
+  });
+
+  it('renders shirt number', () => {
+    render(<PlayerCard playerStats={mockPlayerStats} />);
+    expect(screen.getByText('#10')).toBeInTheDocument();
+  });
+
+  it('renders goalkeeper position badge with correct color class', () => {
+    render(<PlayerCard playerStats={mockGoalkeeperStats} />);
+    expect(screen.getByText('Goalkeeper')).toBeInTheDocument();
+  });
+
+  it('shows 0 goals when total is null', () => {
+    render(<PlayerCard playerStats={mockGoalkeeperStats} />);
+    // goals.total is null → shows 0
+    const goalValues = screen.getAllByText('0');
+    expect(goalValues.length).toBeGreaterThan(0);
+  });
+
+  it('renders player initial when no photo', () => {
+    render(<PlayerCard playerStats={mockPlayerStats} />);
+    expect(screen.getByText('M')).toBeInTheDocument();
+  });
+
+  it('renders player photo when provided', () => {
+    const statsWithPhoto = {
+      ...mockPlayerStats,
+      player: { ...mockPlayerStats.player, photo: 'https://example.com/photo.jpg' },
+    };
+    render(<PlayerCard playerStats={statsWithPhoto} />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg');
+  });
+});

--- a/src/presentation/components/stats/StandingsTable.test.tsx
+++ b/src/presentation/components/stats/StandingsTable.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import { StandingsTable } from './StandingsTable';
+import type { Standing } from '@/shared/types/football';
+
+const mockStandings: Standing[] = [
+  {
+    rank: 1,
+    team: { id: 50, name: 'Manchester City', shortName: 'MCI', logo: '' },
+    points: 72,
+    goalsDiff: 40,
+    group: 'Premier League',
+    form: 'WWWDW',
+    status: 'same',
+    description: 'Promotion - Champions League (Group Stage: )',
+    all: { played: 32, win: 22, draw: 6, lose: 4, goals: { for: 70, against: 30 } },
+    home: { played: 16, win: 12, draw: 2, lose: 2, goals: { for: 38, against: 15 } },
+    away: { played: 16, win: 10, draw: 4, lose: 2, goals: { for: 32, against: 15 } },
+    update: '2025-03-22T00:00:00+00:00',
+  },
+  {
+    rank: 14,
+    team: { id: 33, name: 'Manchester United', shortName: 'MUN', logo: '' },
+    points: 38,
+    goalsDiff: -5,
+    group: 'Premier League',
+    form: 'LWDWL',
+    status: 'same',
+    description: '',
+    all: { played: 32, win: 10, draw: 8, lose: 14, goals: { for: 38, against: 43 } },
+    home: { played: 16, win: 7, draw: 4, lose: 5, goals: { for: 22, against: 20 } },
+    away: { played: 16, win: 3, draw: 4, lose: 9, goals: { for: 16, against: 23 } },
+    update: '2025-03-22T00:00:00+00:00',
+  },
+  {
+    rank: 15,
+    team: { id: 45, name: 'Everton', shortName: 'EVE', logo: '' },
+    points: 35,
+    goalsDiff: -10,
+    group: 'Premier League',
+    form: 'LLDLW',
+    status: 'same',
+    description: '',
+    all: { played: 32, win: 9, draw: 8, lose: 15, goals: { for: 30, against: 40 } },
+    home: { played: 16, win: 5, draw: 5, lose: 6, goals: { for: 18, against: 22 } },
+    away: { played: 16, win: 4, draw: 3, lose: 9, goals: { for: 12, against: 18 } },
+    update: '2025-03-22T00:00:00+00:00',
+  },
+];
+
+describe('StandingsTable', () => {
+  it('renders all team names', () => {
+    render(<StandingsTable standings={mockStandings} />);
+    expect(screen.getByText('Manchester City')).toBeInTheDocument();
+    expect(screen.getByText('Manchester United')).toBeInTheDocument();
+    expect(screen.getByText('Everton')).toBeInTheDocument();
+  });
+
+  it('highlights MU row with mufc-red class', () => {
+    const { container } = render(<StandingsTable standings={mockStandings} highlightTeamId={33} />);
+    const muRow = container.querySelector('tr.bg-mufc-red\\/10');
+    expect(muRow).toBeInTheDocument();
+  });
+
+  it('shows correct points for each team', () => {
+    render(<StandingsTable standings={mockStandings} />);
+    expect(screen.getAllByText('72').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('35').length).toBeGreaterThan(0);
+  });
+
+  it('renders W/D/L counts for a team', () => {
+    render(<StandingsTable standings={mockStandings} />);
+    // MU: win=10, draw=8, lose=14 - use getAllByText since numbers may appear multiple times
+    expect(screen.getAllByText('10').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('14').length).toBeGreaterThan(0);
+  });
+
+  it('renders rank numbers', () => {
+    render(<StandingsTable standings={mockStandings} />);
+    // ranks 1, 14, 15 appear in rank column
+    expect(screen.getAllByText('1').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('15').length).toBeGreaterThan(0);
+  });
+
+  it('renders GF/GA columns when not compact', () => {
+    render(<StandingsTable standings={mockStandings} />);
+    expect(screen.getByText('GF')).toBeInTheDocument();
+    expect(screen.getByText('GA')).toBeInTheDocument();
+  });
+
+  it('does not render GF/GA when compact=true', () => {
+    render(<StandingsTable standings={mockStandings} compact={true} />);
+    expect(screen.queryByText('GF')).not.toBeInTheDocument();
+    expect(screen.queryByText('GA')).not.toBeInTheDocument();
+  });
+
+  it('renders positive goal difference with + prefix', () => {
+    render(<StandingsTable standings={mockStandings} />);
+    expect(screen.getByText('+40')).toBeInTheDocument();
+  });
+
+  it('renders negative goal difference without + prefix', () => {
+    render(<StandingsTable standings={mockStandings} />);
+    expect(screen.getByText('-5')).toBeInTheDocument();
+  });
+
+  it('renders form badges when not compact', () => {
+    render(<StandingsTable standings={mockStandings} />);
+    // Form for MU last 5: L,W,D,W,L → badges
+    const wBadges = screen.getAllByText('W');
+    expect(wBadges.length).toBeGreaterThan(0);
+  });
+
+  it('does not render form column when compact=true', () => {
+    render(<StandingsTable standings={mockStandings} compact={true} />);
+    expect(screen.queryByText('Form')).not.toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/stats/StatCard.test.tsx
+++ b/src/presentation/components/stats/StatCard.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { StatCard } from './StatCard';
+
+describe('StatCard', () => {
+  it('renders title', () => {
+    render(<StatCard title="Goals" value={25} />);
+    expect(screen.getByText('Goals')).toBeInTheDocument();
+  });
+
+  it('renders value', () => {
+    render(<StatCard title="Goals" value={25} />);
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('renders subtitle when provided', () => {
+    render(<StatCard title="Goals" value={25} subtitle="This season" />);
+    expect(screen.getByText('This season')).toBeInTheDocument();
+  });
+
+  it('does not render subtitle when not provided', () => {
+    render(<StatCard title="Goals" value={25} />);
+    expect(screen.queryByText('This season')).not.toBeInTheDocument();
+  });
+
+  it('renders trend label when trend=up and trendLabel provided', () => {
+    render(<StatCard title="Goals" value={25} trend="up" trendLabel="+5%" />);
+    expect(screen.getByText('+5%')).toBeInTheDocument();
+  });
+
+  it('renders trend label when trend=down and trendLabel provided', () => {
+    render(<StatCard title="Goals" value={25} trend="down" trendLabel="-3%" />);
+    expect(screen.getByText('-3%')).toBeInTheDocument();
+  });
+
+  it('renders trend section when trend=neutral', () => {
+    const { container } = render(
+      <StatCard title="Goals" value={25} trend="neutral" trendLabel="0%" />
+    );
+    expect(screen.getByText('0%')).toBeInTheDocument();
+    // neutral trend uses Minus icon - svg should be present
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('does not render trend section when no trend', () => {
+    render(<StatCard title="Goals" value={25} />);
+    // No trendLabel text
+    expect(screen.queryByText('+5%')).not.toBeInTheDocument();
+  });
+
+  it('applies highlight styles when highlight=true', () => {
+    const { container } = render(<StatCard title="Goals" value={25} highlight={true} />);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('border-mufc-red');
+  });
+
+  it('does not apply highlight styles when highlight=false', () => {
+    const { container } = render(<StatCard title="Goals" value={25} highlight={false} />);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).not.toContain('border-mufc-red');
+  });
+
+  it('renders icon when provided', () => {
+    const icon = <span data-testid="custom-icon">★</span>;
+    render(<StatCard title="Goals" value={25} icon={icon} />);
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('renders string value', () => {
+    render(<StatCard title="League" value="Premier League" />);
+    expect(screen.getByText('Premier League')).toBeInTheDocument();
+  });
+});

--- a/src/presentation/components/ui/ThemeProvider.test.tsx
+++ b/src/presentation/components/ui/ThemeProvider.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, useTheme } from './ThemeProvider';
+
+// Helper component to expose the theme context
+function ThemeConsumer() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="current-theme">{theme}</span>
+      <button onClick={() => setTheme('light')}>Set Light</button>
+      <button onClick={() => setTheme('dark')}>Set Dark</button>
+    </div>
+  );
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Remove theme classes from document
+    document.documentElement.classList.remove('light', 'dark');
+  });
+
+  it('renders children', () => {
+    render(
+      <ThemeProvider>
+        <span>Hello</span>
+      </ThemeProvider>
+    );
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('applies dark class to document by default', () => {
+    render(
+      <ThemeProvider defaultTheme="dark">
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('shows current theme value via context', () => {
+    render(
+      <ThemeProvider defaultTheme="dark">
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('dark');
+  });
+
+  it('changes theme when setTheme is called', () => {
+    render(
+      <ThemeProvider defaultTheme="dark">
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByText('Set Light'));
+    expect(screen.getByTestId('current-theme').textContent).toBe('light');
+    expect(document.documentElement.classList.contains('light')).toBe(true);
+  });
+
+  it('persists theme to localStorage', () => {
+    render(
+      <ThemeProvider defaultTheme="dark" storageKey="test-theme-key">
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    fireEvent.click(screen.getByText('Set Light'));
+    expect(localStorage.getItem('test-theme-key')).toBe('light');
+  });
+
+  it('reads theme from localStorage on init', () => {
+    localStorage.setItem('mufc-theme', 'light');
+    render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('current-theme').textContent).toBe('light');
+  });
+
+  it('throws error when useTheme is used outside provider', () => {
+    // Suppress console.error for this test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      render(<ThemeConsumer />);
+      // If it didn't throw, the context returned undefined which triggers the error
+    } catch (e) {
+      expect((e as Error).message).toContain('useTheme must be used within a ThemeProvider');
+    }
+    consoleSpy.mockRestore();
+  });
+
+  it('applies system theme class based on matchMedia', () => {
+    // Mock matchMedia to return dark preference
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    render(
+      <ThemeProvider defaultTheme="system">
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/src/presentation/hooks/useFixtures.test.tsx
+++ b/src/presentation/hooks/useFixtures.test.tsx
@@ -1,0 +1,107 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useFixtures, useUpcomingFixtures, useRecentFixtures } from './useFixtures';
+import type { Fixture } from '@/shared/types/football';
+
+vi.mock('@/infrastructure/api/endpoints/fixtures.api', () => ({
+  fetchFixtures: vi.fn().mockResolvedValue([
+    {
+      id: 1,
+      date: '2025-03-10T15:00:00+00:00',
+      timestamp: 1741618800,
+      status: { long: 'Match Finished', short: 'FT', elapsed: 90 },
+      homeTeam: { id: 33, name: 'Manchester United', logo: '', shortName: 'MUN' },
+      awayTeam: { id: 48, name: 'West Ham', logo: '', shortName: 'WHU' },
+      homeGoals: 2,
+      awayGoals: 1,
+      league: { id: 39, name: 'Premier League', logo: '', round: 'Regular Season - 28' },
+      venue: { name: 'Old Trafford', city: 'Manchester' },
+    },
+    {
+      id: 2,
+      date: '2099-05-01T15:00:00+00:00',
+      timestamp: 4082572800,
+      status: { long: 'Not Started', short: 'NS', elapsed: null },
+      homeTeam: { id: 33, name: 'Manchester United', logo: '', shortName: 'MUN' },
+      awayTeam: { id: 40, name: 'Liverpool', logo: '', shortName: 'LIV' },
+      homeGoals: null,
+      awayGoals: null,
+      league: { id: 39, name: 'Premier League', logo: '', round: 'Regular Season - 35' },
+      venue: { name: 'Old Trafford', city: 'Manchester' },
+    },
+  ]),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useFixtures', () => {
+  it('returns fixture data after loading', async () => {
+    const { result } = renderHook(() => useFixtures(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(2);
+  });
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useFixtures(), { wrapper: createWrapper() });
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('returns data with correct fixture ids', async () => {
+    const { result } = renderHook(() => useFixtures(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const ids = result.current.data?.map((f: Fixture) => f.id);
+    expect(ids).toContain(1);
+    expect(ids).toContain(2);
+  });
+});
+
+describe('useUpcomingFixtures', () => {
+  it('returns only fixtures with timestamp > nowSeconds', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const { result } = renderHook(() => useUpcomingFixtures(nowSeconds), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].id).toBe(2);
+  });
+
+  it('returns empty array when all fixtures are in the past', async () => {
+    const futureSeconds = 9999999999;
+    const { result } = renderHook(() => useUpcomingFixtures(futureSeconds), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(0);
+  });
+});
+
+describe('useRecentFixtures', () => {
+  it('returns only fixtures with timestamp <= nowSeconds', async () => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const { result } = renderHook(() => useRecentFixtures(nowSeconds), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].id).toBe(1);
+  });
+
+  it('returns all fixtures when nowSeconds is in the far future', async () => {
+    const futureSeconds = 9999999999;
+    const { result } = renderHook(() => useRecentFixtures(futureSeconds), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(2);
+  });
+});

--- a/src/presentation/hooks/usePlayerStats.test.tsx
+++ b/src/presentation/hooks/usePlayerStats.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { usePlayerStats } from './usePlayerStats';
+
+vi.mock('@/infrastructure/api/endpoints/players.api', () => ({
+  fetchPlayers: vi.fn().mockResolvedValue([
+    {
+      player: {
+        id: 276,
+        name: 'Marcus Rashford',
+        age: 27,
+        nationality: 'England',
+        position: 'Attacker',
+        photo: '',
+      },
+      statistics: [
+        {
+          games: {
+            appearances: 30,
+            lineups: 28,
+            minutes: 2400,
+            number: 10,
+            position: 'Attacker',
+            rating: '7.5',
+            captain: false,
+          },
+          goals: { total: 12, conceded: 0, assists: 5, saves: null },
+          shots: { total: 55, on: 28 },
+          passes: { total: 600, key: 40, accuracy: '78' },
+          tackles: { total: 20, blocks: 3, interceptions: 10 },
+          cards: { yellow: 2, yellowred: 0, red: 0 },
+        },
+      ],
+    },
+  ]),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('usePlayerStats', () => {
+  it('returns player data after loading', async () => {
+    const { result } = renderHook(() => usePlayerStats(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].player.name).toBe('Marcus Rashford');
+  });
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => usePlayerStats(), { wrapper: createWrapper() });
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('returns correct goal count', async () => {
+    const { result } = renderHook(() => usePlayerStats(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].statistics[0].goals.total).toBe(12);
+  });
+});

--- a/src/presentation/hooks/useSeasonPerformance.test.tsx
+++ b/src/presentation/hooks/useSeasonPerformance.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSeasonPerformance } from './useSeasonPerformance';
+
+// Mock the JSON import via the module that uses it
+vi.mock('@/infrastructure/api/mocks/seasonPerformance.mock.json', () => ({
+  default: {
+    data: [
+      { matchday: 'GW1', goals: 2, goalsAgainst: 1, points: 3 },
+      { matchday: 'GW2', goals: 0, goalsAgainst: 0, points: 1 },
+      { matchday: 'GW3', goals: 3, goalsAgainst: 2, points: 3 },
+    ],
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useSeasonPerformance', () => {
+  it('returns season performance data after loading', async () => {
+    const { result } = renderHook(() => useSeasonPerformance(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(3);
+  });
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useSeasonPerformance(), { wrapper: createWrapper() });
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('returns correct matchday data', async () => {
+    const { result } = renderHook(() => useSeasonPerformance(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].matchday).toBe('GW1');
+    expect(result.current.data?.[0].goals).toBe(2);
+    expect(result.current.data?.[0].goalsAgainst).toBe(1);
+    expect(result.current.data?.[0].points).toBe(3);
+  });
+});

--- a/src/presentation/hooks/useStandings.test.tsx
+++ b/src/presentation/hooks/useStandings.test.tsx
@@ -1,0 +1,51 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useStandings } from './useStandings';
+
+vi.mock('@/infrastructure/api/endpoints/standings.api', () => ({
+  fetchStandings: vi.fn().mockResolvedValue([
+    {
+      rank: 1,
+      team: { id: 50, name: 'Manchester City', shortName: 'MCI', logo: '' },
+      points: 72,
+      goalsDiff: 40,
+      group: 'Premier League',
+      form: 'WWWDW',
+      status: 'same',
+      description: '',
+      all: { played: 32, win: 22, draw: 6, lose: 4, goals: { for: 70, against: 30 } },
+      home: { played: 16, win: 12, draw: 2, lose: 2, goals: { for: 38, against: 15 } },
+      away: { played: 16, win: 10, draw: 4, lose: 2, goals: { for: 32, against: 15 } },
+      update: '2025-03-22T00:00:00+00:00',
+    },
+  ]),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useStandings', () => {
+  it('returns standings data after loading', async () => {
+    const { result } = renderHook(() => useStandings(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].team.name).toBe('Manchester City');
+  });
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useStandings(), { wrapper: createWrapper() });
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('returns correct points', async () => {
+    const { result } = renderHook(() => useStandings(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].points).toBe(72);
+  });
+});

--- a/src/presentation/hooks/useTeamStats.test.tsx
+++ b/src/presentation/hooks/useTeamStats.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useTeamStats } from './useTeamStats';
+
+vi.mock('@/infrastructure/api/endpoints/teams.api', () => ({
+  fetchTeamStatistics: vi.fn().mockResolvedValue({
+    team: { id: 33, name: 'Manchester United', shortName: 'MUN', logo: '' },
+    league: { id: 39, name: 'Premier League', season: 2024 },
+    form: 'WDLWW',
+    fixtures: {
+      played: { home: 16, away: 16, total: 32 },
+      wins: { home: 7, away: 3, total: 10 },
+      draws: { home: 4, away: 4, total: 8 },
+      loses: { home: 5, away: 9, total: 14 },
+    },
+    goals: {
+      for: {
+        total: { home: 22, away: 16, total: 38 },
+        average: { home: '1.4', away: '1.0', total: '1.2' },
+      },
+      against: {
+        total: { home: 20, away: 23, total: 43 },
+        average: { home: '1.3', away: '1.4', total: '1.3' },
+      },
+    },
+    cleanSheets: { home: 5, away: 3, total: 8 },
+    failedToScore: { home: 3, away: 5, total: 8 },
+  }),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useTeamStats', () => {
+  it('returns team statistics after loading', async () => {
+    const { result } = renderHook(() => useTeamStats(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.team.name).toBe('Manchester United');
+  });
+
+  it('starts in loading state', () => {
+    const { result } = renderHook(() => useTeamStats(), { wrapper: createWrapper() });
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('returns correct goals for total', async () => {
+    const { result } = renderHook(() => useTeamStats(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.goals.for.total.total).toBe(38);
+  });
+
+  it('returns correct form string', async () => {
+    const { result } = renderHook(() => useTeamStats(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.form).toBe('WDLWW');
+  });
+});

--- a/src/presentation/store/apiLimitStore.test.ts
+++ b/src/presentation/store/apiLimitStore.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock, writable: true });
+
+vi.mock('@/shared/config/env', () => ({
+  env: {
+    apiFootballKey: 'test-key',
+    apiFootballBaseUrl: 'https://v3.football.api-sports.io',
+    useMockData: true,
+    teamId: 33,
+    apiRateLimit: 100,
+  },
+}));
+
+import { useApiLimitStore } from './apiLimitStore';
+
+describe('apiLimitStore', () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    // Reset store state
+    useApiLimitStore.setState({
+      usedRequests: 0,
+      maxRequests: 100,
+      limitReached: false,
+    });
+  });
+
+  it('initial maxRequests is 100 (from env.apiRateLimit)', () => {
+    const state = useApiLimitStore.getState();
+    expect(state.maxRequests).toBe(100);
+  });
+
+  it('initial usedRequests is 0 when localStorage is empty', () => {
+    useApiLimitStore.setState({ usedRequests: 0 });
+    const state = useApiLimitStore.getState();
+    expect(state.usedRequests).toBe(0);
+  });
+
+  it('initial limitReached is false when no requests made', () => {
+    const state = useApiLimitStore.getState();
+    expect(state.limitReached).toBe(false);
+  });
+
+  it('checkLimit updates usedRequests from localStorage', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('mufc_api_requests_date', today);
+    localStorage.setItem('mufc_api_requests', '42');
+    const { checkLimit } = useApiLimitStore.getState();
+    checkLimit();
+    expect(useApiLimitStore.getState().usedRequests).toBe(42);
+  });
+
+  it('checkLimit updates limitReached to true when at limit', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('mufc_api_requests_date', today);
+    localStorage.setItem('mufc_api_requests', '100');
+    const { checkLimit } = useApiLimitStore.getState();
+    checkLimit();
+    expect(useApiLimitStore.getState().limitReached).toBe(true);
+  });
+
+  it('checkLimit updates limitReached to false when below limit', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('mufc_api_requests_date', today);
+    localStorage.setItem('mufc_api_requests', '50');
+    const { checkLimit } = useApiLimitStore.getState();
+    checkLimit();
+    expect(useApiLimitStore.getState().limitReached).toBe(false);
+    expect(useApiLimitStore.getState().usedRequests).toBe(50);
+  });
+
+  it('refreshCount updates usedRequests from localStorage', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    localStorage.setItem('mufc_api_requests_date', today);
+    localStorage.setItem('mufc_api_requests', '75');
+    const { refreshCount } = useApiLimitStore.getState();
+    refreshCount();
+    expect(useApiLimitStore.getState().usedRequests).toBe(75);
+  });
+});

--- a/src/presentation/store/appStore.test.ts
+++ b/src/presentation/store/appStore.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useAppStore } from './appStore';
+
+describe('appStore', () => {
+  beforeEach(() => {
+    // Reset store to initial state between tests
+    useAppStore.setState({
+      sidebarOpen: true,
+      selectedLeagueId: 39,
+      selectedSeason: 2024,
+    });
+  });
+
+  it('initial state has selectedLeagueId 39 (Premier League)', () => {
+    const state = useAppStore.getState();
+    expect(state.selectedLeagueId).toBe(39);
+  });
+
+  it('initial state has selectedSeason 2024', () => {
+    const state = useAppStore.getState();
+    expect(state.selectedSeason).toBe(2024);
+  });
+
+  it('initial state has sidebarOpen true', () => {
+    const state = useAppStore.getState();
+    expect(state.sidebarOpen).toBe(true);
+  });
+
+  it('setSelectedLeagueId updates selectedLeagueId', () => {
+    const { setSelectedLeagueId } = useAppStore.getState();
+    setSelectedLeagueId(140); // La Liga
+    expect(useAppStore.getState().selectedLeagueId).toBe(140);
+  });
+
+  it('setSelectedSeason updates selectedSeason', () => {
+    const { setSelectedSeason } = useAppStore.getState();
+    setSelectedSeason(2023);
+    expect(useAppStore.getState().selectedSeason).toBe(2023);
+  });
+
+  it('setSidebarOpen updates sidebarOpen', () => {
+    const { setSidebarOpen } = useAppStore.getState();
+    setSidebarOpen(false);
+    expect(useAppStore.getState().sidebarOpen).toBe(false);
+  });
+
+  it('setSidebarOpen can toggle back to true', () => {
+    const { setSidebarOpen } = useAppStore.getState();
+    setSidebarOpen(false);
+    setSidebarOpen(true);
+    expect(useAppStore.getState().sidebarOpen).toBe(true);
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -38,5 +38,6 @@
       "@shared/*": ["./src/shared/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: 'jsdom',
+    environment: 'happy-dom',
     setupFiles: './src/test/setup.ts',
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Description
Adds unit tests for all Phase 2 and Phase 3 code. Resolves the jsdom 27 + @csstools/css-calc ESM incompatibility by switching to `happy-dom` test environment.

## Related Issue
Closes #4

## Changes
- Tests for all stat components: StatCard, MatchCard, PlayerCard, StandingsTable
- Tests for all chart components: SeasonPerformanceChart, MatchStatsChart, PlayerRadarChart (recharts mocked)
- Tests for all feedback components: LoadingSpinner, ErrorMessage, EmptyState, ApiLimitReached
- Tests for layout components: Sidebar, Header (with MemoryRouter/ThemeProvider wrapping)
- Tests for ThemeProvider (renders children, dark default, setTheme, localStorage persistence)
- Tests for API rate limit utility (getApiRequestCount, incrementApiRequestCount, isApiLimitReached, day reset)
- Tests for Zustand stores: appStore, apiLimitStore
- Tests for custom React Query hooks: useFixtures, useUpcomingFixtures, useRecentFixtures, useStandings, useTeamStats, usePlayerStats, useSeasonPerformance
- Switch test environment from jsdom → happy-dom to fix ESM incompatibility with Node 20
- Exclude test files from tsconfig.app.json to fix build

## Test Results
- 22 test files, 155 tests — all passing
- Coverage: 91% Statements | 88% Branches | 89% Functions | 92% Lines

## Checklist
- [x] Tests added
- [x] Build passes
- [x] Lint passes (0 errors)
- [x] Coverage ≥80% on all metrics
- [x] Self-review completed