### PR TITLE
feat(api): add fixture events endpoint

### DIFF
--- a/src/infrastructure/api/endpoints/fixtureEvents.api.test.ts
+++ b/src/infrastructure/api/endpoints/fixtureEvents.api.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchFixtureEvents } from './fixtureEvents.api';
+import { footballApiClient } from '../footballApi';
+import { env } from '@/shared/config/env';
+
+vi.mock('../footballApi', () => ({
+  footballApiClient: { get: vi.fn() },
+}));
+
+vi.mock('@/shared/config/env', () => ({
+  env: { useMockData: false },
+}));
+
+const mockGet = vi.mocked(footballApiClient.get);
+
+describe('fetchFixtureEvents', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  afterEach(() => {
+    vi.mocked(env).useMockData = false;
+  });
+
+  it('calls /fixtures/events with fixtureId', async () => {
+    mockGet.mockResolvedValueOnce({ data: { response: [] } });
+    await fetchFixtureEvents(215662);
+    expect(mockGet).toHaveBeenCalledWith('/fixtures/events', {
+      params: { fixture: 215662 },
+    });
+  });
+
+  it('returns mapped events array', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        response: [
+          {
+            time: { elapsed: 12, extra: null },
+            team: { id: 33, name: 'Manchester United', logo: '' },
+            player: { id: 19185, name: 'M. Rashford' },
+            assist: { id: null, name: null },
+            type: 'Goal',
+            detail: 'Normal Goal',
+            comments: null,
+          },
+        ],
+      },
+    });
+
+    const result = await fetchFixtureEvents(215662);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('Goal');
+    expect(result[0].player.name).toBe('M. Rashford');
+    expect(result[0].time.elapsed).toBe(12);
+  });
+
+  it('returns empty array when API returns no events', async () => {
+    mockGet.mockResolvedValueOnce({ data: { response: [] } });
+    const result = await fetchFixtureEvents(99999);
+    expect(result).toEqual([]);
+  });
+
+  it('returns mock data when useMockData is true', async () => {
+    vi.mocked(env).useMockData = true;
+    const result = await fetchFixtureEvents(1);
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(result.length).toBeGreaterThan(0);
+  });
+});

--- a/src/infrastructure/api/endpoints/fixtureEvents.api.ts
+++ b/src/infrastructure/api/endpoints/fixtureEvents.api.ts
@@ -1,0 +1,14 @@
+import { footballApiClient } from '../footballApi';
+import { env } from '@/shared/config/env';
+import fixtureEventsMock from '../mocks/fixtureEvents.mock.json';
+import type { FixtureEvent } from '@/shared/types/football';
+
+export async function fetchFixtureEvents(fixtureId: number): Promise<FixtureEvent[]> {
+  if (env.useMockData) {
+    return fixtureEventsMock.response as unknown as FixtureEvent[];
+  }
+  const { data } = await footballApiClient.get('/fixtures/events', {
+    params: { fixture: fixtureId },
+  });
+  return data.response as FixtureEvent[];
+}

--- a/src/infrastructure/api/mocks/fixtureEvents.mock.json
+++ b/src/infrastructure/api/mocks/fixtureEvents.mock.json
@@ -1,0 +1,31 @@
+{
+  "response": [
+    {
+      "time": { "elapsed": 12, "extra": null },
+      "team": { "id": 33, "name": "Manchester United", "logo": "" },
+      "player": { "id": 19185, "name": "M. Rashford" },
+      "assist": { "id": null, "name": null },
+      "type": "Goal",
+      "detail": "Normal Goal",
+      "comments": null
+    },
+    {
+      "time": { "elapsed": 34, "extra": null },
+      "team": { "id": 40, "name": "Liverpool", "logo": "" },
+      "player": { "id": 18978, "name": "M. Salah" },
+      "assist": { "id": null, "name": null },
+      "type": "Card",
+      "detail": "Yellow Card",
+      "comments": null
+    },
+    {
+      "time": { "elapsed": 45, "extra": 2 },
+      "team": { "id": 33, "name": "Manchester United", "logo": "" },
+      "player": { "id": 521, "name": "B. Fernandes" },
+      "assist": { "id": null, "name": null },
+      "type": "Goal",
+      "detail": "Penalty",
+      "comments": null
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `fetchFixtureEvents(fixtureId)` calling `GET /fixtures/events?fixture={id}`
- Mock fallback via `fixtureEvents.mock.json` when `env.useMockData` is true
- Full TDD: 4 unit tests covering API call, response mapping, empty array, and mock mode

## Test plan

- [x] Tests fail before implementation (import error)
- [x] All 4 unit tests pass after implementation
- [x] Full suite: 250/250 tests passing

Closes #19