### PR TITLE
feat(api): add fixture statistics endpoint

### DIFF
--- a/src/infrastructure/api/endpoints/fixtureStatistics.api.test.ts
+++ b/src/infrastructure/api/endpoints/fixtureStatistics.api.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchFixtureStatistics } from './fixtureStatistics.api';
+import { footballApiClient } from '../footballApi';
+import { env } from '@/shared/config/env';
+
+vi.mock('../footballApi', () => ({
+  footballApiClient: { get: vi.fn() },
+}));
+
+vi.mock('@/shared/config/env', () => ({
+  env: { useMockData: false },
+}));
+
+const mockGet = vi.mocked(footballApiClient.get);
+
+describe('fetchFixtureStatistics', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  afterEach(() => {
+    vi.mocked(env).useMockData = false;
+  });
+
+  it('calls /fixtures/statistics with fixtureId', async () => {
+    mockGet.mockResolvedValueOnce({ data: { response: [] } });
+    await fetchFixtureStatistics(215662);
+    expect(mockGet).toHaveBeenCalledWith('/fixtures/statistics', {
+      params: { fixture: 215662 },
+    });
+  });
+
+  it('returns two team stat objects', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        response: [
+          {
+            team: { id: 33, name: 'Manchester United', logo: '' },
+            statistics: [
+              { type: 'Ball Possession', value: '54%' },
+              { type: 'Total Shots', value: 14 },
+            ],
+          },
+          {
+            team: { id: 40, name: 'Liverpool', logo: '' },
+            statistics: [
+              { type: 'Ball Possession', value: '46%' },
+              { type: 'Total Shots', value: 9 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchFixtureStatistics(215662);
+    expect(result).toHaveLength(2);
+    expect(result[0].team.id).toBe(33);
+    expect(result[0].statistics[0].type).toBe('Ball Possession');
+    expect(result[0].statistics[0].value).toBe('54%');
+    expect(result[1].team.id).toBe(40);
+  });
+
+  it('returns empty array when API returns no stats', async () => {
+    mockGet.mockResolvedValueOnce({ data: { response: [] } });
+    const result = await fetchFixtureStatistics(99999);
+    expect(result).toEqual([]);
+  });
+
+  it('returns mock data when useMockData is true', async () => {
+    vi.mocked(env).useMockData = true;
+    const result = await fetchFixtureStatistics(1);
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+    expect(result[0].team.id).toBe(33);
+  });
+});

--- a/src/infrastructure/api/endpoints/fixtureStatistics.api.ts
+++ b/src/infrastructure/api/endpoints/fixtureStatistics.api.ts
@@ -1,0 +1,14 @@
+import { footballApiClient } from '../footballApi';
+import { env } from '@/shared/config/env';
+import fixtureStatsMock from '../mocks/fixtureStatistics.mock.json';
+import type { FixtureStatTeam } from '@/shared/types/football';
+
+export async function fetchFixtureStatistics(fixtureId: number): Promise<FixtureStatTeam[]> {
+  if (env.useMockData) {
+    return fixtureStatsMock.response as unknown as FixtureStatTeam[];
+  }
+  const { data } = await footballApiClient.get('/fixtures/statistics', {
+    params: { fixture: fixtureId },
+  });
+  return data.response as FixtureStatTeam[];
+}

--- a/src/infrastructure/api/mocks/fixtureStatistics.mock.json
+++ b/src/infrastructure/api/mocks/fixtureStatistics.mock.json
@@ -1,0 +1,30 @@
+{
+  "response": [
+    {
+      "team": { "id": 33, "name": "Manchester United", "logo": "" },
+      "statistics": [
+        { "type": "Ball Possession", "value": "54%" },
+        { "type": "Total Shots", "value": 14 },
+        { "type": "Shots on Goal", "value": 6 },
+        { "type": "Corner Kicks", "value": 7 },
+        { "type": "Fouls", "value": 8 },
+        { "type": "Yellow Cards", "value": 1 },
+        { "type": "Red Cards", "value": 0 },
+        { "type": "Offsides", "value": 2 }
+      ]
+    },
+    {
+      "team": { "id": 40, "name": "Liverpool", "logo": "" },
+      "statistics": [
+        { "type": "Ball Possession", "value": "46%" },
+        { "type": "Total Shots", "value": 9 },
+        { "type": "Shots on Goal", "value": 3 },
+        { "type": "Corner Kicks", "value": 4 },
+        { "type": "Fouls", "value": 12 },
+        { "type": "Yellow Cards", "value": 2 },
+        { "type": "Red Cards", "value": 0 },
+        { "type": "Offsides", "value": 1 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds fetchFixtureStatistics() calling GET /fixtures/statistics. Includes mock fallback via env.useMockData. Closes #21