### PR TITLE
feat(hooks): add useFixtureDetail hook

### DIFF
--- a/src/presentation/hooks/useFixtureDetail.test.ts
+++ b/src/presentation/hooks/useFixtureDetail.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement } from 'react';
@@ -26,6 +26,11 @@ function createWrapper() {
 }
 
 describe('useFixtureDetail', () => {
+  beforeEach(() => {
+    mockFetchFixtureEvents.mockReset();
+    mockFetchFixtureStatistics.mockReset();
+  });
+
   it('does not fetch when fixtureId is undefined', () => {
     const { result } = renderHook(() => useFixtureDetail(undefined), {
       wrapper: createWrapper(),

--- a/src/presentation/hooks/useFixtureDetail.ts
+++ b/src/presentation/hooks/useFixtureDetail.ts
@@ -3,6 +3,13 @@ import { fetchFixtureEvents } from '@/infrastructure/api/endpoints/fixtureEvents
 import { fetchFixtureStatistics } from '@/infrastructure/api/endpoints/fixtureStatistics.api';
 import type { FixtureEvent, FixtureStatTeam } from '@/shared/types/football';
 
+/**
+ * Fetches fixture events and statistics for a given fixture ID.
+ *
+ * Both queries are disabled when `fixtureId` is `undefined`.
+ * Note: `events` and `statistics` are `undefined` both while loading
+ * AND when `fixtureId` is `undefined` — consumers must handle both cases.
+ */
 export function useFixtureDetail(fixtureId: number | undefined) {
   const eventsQuery = useQuery<FixtureEvent[]>({
     queryKey: ['fixture', 'events', fixtureId],


### PR DESCRIPTION
## Summary

- Combined React Query hook that fetches fixture events and statistics for a given fixture ID
- Disabled (no fetch) when `fixtureId` is `undefined`
- Exposes `events`, `statistics`, `isLoading`, and `isError` from both parallel queries

## Test plan

- [x] Does not fetch when `fixtureId` is undefined
- [x] Fetches events and statistics when `fixtureId` is provided
- [x] Reflects error state when events query fails
- [x] Full suite: 257 tests across 33 files — all passing

Closes #23