### PR TITLE
feat(pages): connect LiveMatchPage to real data

### DIFF
--- a/src/presentation/pages/LiveMatchPage.test.tsx
+++ b/src/presentation/pages/LiveMatchPage.test.tsx
@@ -139,6 +139,20 @@ describe('LiveMatchPage', () => {
     expect(screen.getByText('Loading events...')).toBeInTheDocument();
   });
 
+  it('shows error state when detail query fails', async () => {
+    mockUseRecentFixtures.mockReturnValue({ data: [mockFixture], isLoading: false });
+    mockUseFixtureDetail.mockReturnValue({
+      events: undefined,
+      statistics: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    render(createElement(LiveMatchPage), { wrapper: createWrapper() });
+    expect(screen.getByText('Failed to load statistics')).toBeInTheDocument();
+    expect(screen.getByText('Failed to load events')).toBeInTheDocument();
+  });
+
   it('shows empty fallback when no events available', async () => {
     mockUseRecentFixtures.mockReturnValue({ data: [mockFixture], isLoading: false });
     mockUseFixtureDetail.mockReturnValue({

--- a/src/presentation/pages/LiveMatchPage.tsx
+++ b/src/presentation/pages/LiveMatchPage.tsx
@@ -14,9 +14,9 @@ function parseStatValue(value: number | string | boolean | null): number {
   return parseInt(value.replace('%', ''), 10) || 0;
 }
 
-function buildMatchStats(stats: FixtureStatTeam[], homeTeamId: number) {
+function buildMatchStats(stats: FixtureStatTeam[], homeTeamId: number, awayTeamId: number) {
   const homeStats = stats.find((s) => s.team.id === homeTeamId);
-  const awayStats = stats.find((s) => s.team.id !== homeTeamId);
+  const awayStats = stats.find((s) => s.team.id === awayTeamId);
   if (!homeStats || !awayStats) return [];
 
   const statTypes = [
@@ -42,7 +42,12 @@ export function LiveMatchPage() {
   const [now] = useState(() => Math.floor(Date.now() / 1000));
   const { data: recent, isLoading } = useRecentFixtures(now);
   const lastMatch = recent?.[0];
-  const { events, statistics, isLoading: detailLoading } = useFixtureDetail(lastMatch?.id);
+  const {
+    events,
+    statistics,
+    isLoading: detailLoading,
+    isError: detailError,
+  } = useFixtureDetail(lastMatch?.id);
 
   if (isLoading) return <LoadingPage />;
   if (!lastMatch)
@@ -52,7 +57,9 @@ export function LiveMatchPage() {
 
   const homeTeamName = lastMatch.homeTeam.name;
   const awayTeamName = lastMatch.awayTeam.name;
-  const matchStats = statistics ? buildMatchStats(statistics, lastMatch.homeTeam.id) : [];
+  const matchStats = statistics
+    ? buildMatchStats(statistics, lastMatch.homeTeam.id, lastMatch.awayTeam.id)
+    : [];
 
   return (
     <div className="space-y-6">
@@ -94,6 +101,8 @@ export function LiveMatchPage() {
             <p className="text-sm text-muted-foreground">Loading statistics...</p>
           ) : matchStats.length > 0 ? (
             <MatchStatsChart stats={matchStats} homeTeam={homeTeamName} awayTeam={awayTeamName} />
+          ) : detailError ? (
+            <p className="text-sm text-red-400">Failed to load statistics</p>
           ) : (
             <p className="text-sm text-muted-foreground">No statistics available</p>
           )}
@@ -128,6 +137,8 @@ export function LiveMatchPage() {
                 );
               })}
             </div>
+          ) : detailError ? (
+            <p className="text-sm text-red-400">Failed to load events</p>
           ) : (
             <p className="text-sm text-muted-foreground">No events available</p>
           )}


### PR DESCRIPTION
## Summary

- Removes `MOCK_MATCH_EVENTS` and `MOCK_MATCH_STATS` hardcoded constants from `LiveMatchPage.tsx`
- Integrates `useFixtureDetail` hook to fetch real events and statistics from the API
- Handles loading, empty, and error states gracefully with proper UI feedback

## Changes

- `LiveMatchPage.tsx`: replaced mock constants with `useFixtureDetail(lastMatch?.id)`, added `parseStatValue` and `buildMatchStats` helpers to transform API data into chart-compatible format
- `LiveMatchPage.test.tsx`: rewrote tests with `vi.hoisted` pattern mocking both `useRecentFixtures` and `useFixtureDetail`; 5 focused tests covering loading, empty, real data, detail loading, and empty fallback states

## Test plan

- [x] `shows loading state` — spinner visible, heading absent
- [x] `shows empty state when no recent fixtures` — EmptyState with correct title
- [x] `shows real match events when available` — player name and event type rendered
- [x] `shows loading state for detail while fixture is set` — inline loading text for stats and events
- [x] `shows empty fallback when no events available` — fallback messages rendered
- [x] Full suite: 248/248 tests passing

Closes #25